### PR TITLE
Simplify aggregation

### DIFF
--- a/aggregate.py
+++ b/aggregate.py
@@ -79,17 +79,7 @@ for repo_url, repo_config in coin_config.items():
         proto_dir = os.path.join(repo_dir, proto_folder)
         proto_path_list = proto_folder.split('/')
         target = repo_config["target"] + "/" if "target" in repo_config else ""
-
-        # If the path consists of 2 or less consider the latest entry to be the according path
-        if len(proto_path_list) <= 2:
-            proto_path_in_repo = proto_path_list[-1]
-        else: # If the path has more than 2 items remove the first one and take the rest
-            proto_path_list.pop(0)
-            proto_path_in_repo = "/".join(proto_path_list)
-
-        # Fix compiling for Google protobuf
-        if proto_path_in_repo == 'proto/google':
-            proto_path_in_repo = proto_path_in_repo.split('/')[1]
+        proto_path_in_repo = proto_path_list[-1]
 
         try:
             shutil.copytree(proto_dir, root_abs_path + "/" + (target if target else proto_path_in_repo), dirs_exist_ok=True, ignore=include_patterns("*.proto"))

--- a/configs/cosmos.json
+++ b/configs/cosmos.json
@@ -1,37 +1,37 @@
 {
   "https://github.com/cosmos/cosmos-sdk.git": {
     "include": true,
-    "branch": "v0.45.13-ics",
+    "branch": "v0.45.16-ics",
     "paths": ["proto/cosmos"]
   },
-  "https://github.com/informalsystems/tendermint.git": {
+  "https://github.com/cometbft/cometbft.git": {
     "include": true,
-    "branch": "v0.34.26",
+    "branch": "v0.34.29",
     "paths": ["proto/tendermint"]
   },
   "https://github.com/cosmos/ibc-go": {
     "include": true,
-    "branch": "v4.2.0",
-    "paths": ["proto/ibc", "third_party/proto/google"]
+    "branch": "v4.4.2",
+    "paths": ["proto/ibc"]
   },
   "https://github.com/cosmos/cosmos-proto.git": {
     "include": true,
-    "branch": "main",
+    "branch": "v1.0.0-beta.1",
     "paths": ["proto/cosmos_proto"]
   },
-  "https://github.com/cosmos/gogoproto.git": {
+  "https://github.com/regen-network/protobuf.git": {
     "include": true,
-    "branch": "main",
+    "branch": "v1.3.3-alpha.regen.1",
     "paths": ["gogoproto"]
   },
   "https://github.com/confio/ics23.git": {
     "include": true,
-    "branch": "master",
-    "paths": ["proto/cosmos/ics23/v1/proofs.proto"]
+    "branch": "go/v0.9.0",
+    "paths": ["proofs.proto"]
   },
   "https://github.com/cosmos/interchain-security.git": {
     "include": true,
-    "branch": "v1.0.0",
-    "paths": ["proto/interchain_security/ccv"]
+    "branch": "v2.0.0",
+    "paths": ["proto/interchain_security", "third_party/google"]
   }
 }


### PR DESCRIPTION
This is a change I'm using locally to ease integratation of more chains.

The protobuf path algorithm is simplified to take only the last component.

Right now I have only added a port and upgrade for cosmos, mostly because I haven't finished porting osmosis yet, it has breaking changes between versions and the node I use recently upgraded to v16, whereas the repository has v14 ... locally i am using different packages for these (osmosis14_protobuf, osmosis15_protobuf, osmosis16_protobuf).

I remove the official google protobufs because google's packages build them with a different compiler version, which clashes.